### PR TITLE
fix action build with read only permissions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -75,6 +75,8 @@ jobs:
     needs: [check-changes, build]
     if: needs.check-changes.outputs.has-changes == '1'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_SHA: ${{ github.sha }}

--- a/build.sh
+++ b/build.sh
@@ -4,10 +4,10 @@ set -eu -o pipefail
 BUILD_TARGET="$1"
 PACKAGE_NAME="$2"
 
-echo "Building for target: $BUILD_TARGET"
+echo "Building for target: $BUILD_TARGET" >&2
 cargo build --release --target "$BUILD_TARGET"
 
-echo "Copying binary as: $PACKAGE_NAME"
+echo "Copying binary as: $PACKAGE_NAME" >&2
 cp "target/$BUILD_TARGET/release/dsv" "$PACKAGE_NAME"
 
-echo "Build complete: $PACKAGE_NAME"
+echo "Build complete: $PACKAGE_NAME" >&2

--- a/release.sh
+++ b/release.sh
@@ -8,21 +8,23 @@ if [ ! -d "artifacts" ] || [ -z "$(find artifacts -name 'dsv-nightly-*' -type f)
 fi
 
 # Delete previous nightly release and tag
-echo "Deleting previous nightly release..."
-gh release delete nightly --yes || echo "No previous nightly release found"
-git push origin --delete nightly || echo "No nightly tag found"
+echo "Deleting previous nightly release..." >&2
+if gh release view nightly >/dev/null; then
+    gh release delete nightly --yes
+    git push origin --delete nightly
+fi
 
 # Create nightly tag
-echo "Creating nightly tag..."
+echo "Creating nightly tag..." >&2
 git config user.name "github-actions[bot]"
 git config user.email "github-actions[bot]@users.noreply.github.com"
 git tag -f nightly
 git push origin nightly -f
 
 # Generate release notes
-echo "Generating release notes..."
+echo "Generating release notes..." >&2
 cat > release_notes.md << EOF
-# DSV Nightly Release
+# dsv nightly release
 
 Automated nightly build from commit: \`${GITHUB_SHA}\`
 
@@ -32,18 +34,20 @@ Built on: $(date -u '+%Y-%m-%d %H:%M:%S UTC')
 
 Choose the appropriate binary for your platform:
 
-- **Linux x86_64**: \`dsv-nightly-x86_64-linux\`
-- **Linux ARM64**: \`dsv-nightly-aarch64-linux\`
+- **Linux x86_64**: [dsv-nightly-x86_64-linux](https://github.com/lincheney/dsv/releases/download/nightly/dsv-nightly-x86_64-linux)
+    - `wget https://github.com/lincheney/dsv/releases/download/nightly/dsv-nightly-x86_64-linux`
+- **Linux ARM64**: [dsv-nightly-aarch64-linux](https://github.com/lincheney/dsv/releases/download/nightly/dsv-nightly-aarch64-linux)
+    - `wget https://github.com/lincheney/dsv/releases/download/nightly/dsv-nightly-aarch64-linux`
 
 ⚠️  **Note**: This is a pre-release build and may contain unstable features.
 EOF
 
 # Create nightly release with only available artifacts
-echo "Creating nightly release..."
+echo "Creating nightly release..." >&2
 gh release create nightly \
-  --title "DSV Nightly $(date -u '+%Y-%m-%d')" \
+  --title "dsv nightly $(date -u '+%Y-%m-%d')" \
   --notes-file release_notes.md \
   --prerelease \
   artifacts/**/*
 
-echo "Nightly release created successfully!"
+echo "Nightly release created successfully!" >&2

--- a/release.sh
+++ b/release.sh
@@ -36,7 +36,7 @@ Choose the appropriate binary for your platform:
 
 - **Linux x86_64**: [dsv-nightly-x86_64-linux]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/download/nightly/dsv-nightly-x86_64-linux)
     - \`wget $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/download/nightly/dsv-nightly-x86_64-linux\`
-- **Linux ARM64**: [dsv-nightly-aarch64-linux]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/dsv/releases/download/nightly/dsv-nightly-aarch64-linux)
+- **Linux ARM64**: [dsv-nightly-aarch64-linux]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/download/nightly/dsv-nightly-aarch64-linux)
     - \`wget $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/download/nightly/dsv-nightly-aarch64-linux\`
 
 ⚠️  **Note**: This is a pre-release build and may contain unstable features.

--- a/release.sh
+++ b/release.sh
@@ -34,10 +34,10 @@ Built on: $(date -u '+%Y-%m-%d %H:%M:%S UTC')
 
 Choose the appropriate binary for your platform:
 
-- **Linux x86_64**: [dsv-nightly-x86_64-linux](https://github.com/lincheney/dsv/releases/download/nightly/dsv-nightly-x86_64-linux)
-    - `wget https://github.com/lincheney/dsv/releases/download/nightly/dsv-nightly-x86_64-linux`
-- **Linux ARM64**: [dsv-nightly-aarch64-linux](https://github.com/lincheney/dsv/releases/download/nightly/dsv-nightly-aarch64-linux)
-    - `wget https://github.com/lincheney/dsv/releases/download/nightly/dsv-nightly-aarch64-linux`
+- **Linux x86_64**: [dsv-nightly-x86_64-linux]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/download/nightly/dsv-nightly-x86_64-linux)
+    - \`wget $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/download/nightly/dsv-nightly-x86_64-linux\`
+- **Linux ARM64**: [dsv-nightly-aarch64-linux]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/dsv/releases/download/nightly/dsv-nightly-aarch64-linux)
+    - \`wget $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/download/nightly/dsv-nightly-aarch64-linux\`
 
 ⚠️  **Note**: This is a pre-release build and may contain unstable features.
 EOF

--- a/release.sh
+++ b/release.sh
@@ -26,7 +26,7 @@ echo "Generating release notes..." >&2
 cat > release_notes.md << EOF
 # dsv nightly release
 
-Automated nightly build from commit: \`${GITHUB_SHA}\`
+Automated nightly build from commit: [$GITHUB_SHA]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$GITHUB_SHA)
 
 Built on: $(date -u '+%Y-%m-%d %H:%M:%S UTC')
 


### PR DESCRIPTION
actions by default has read only perms, not sure why mine was set to r+w
i've added in the permission to the job to delete/create releases

* before (setting to read only): https://github.com/itsjfx/dsv/actions/runs/18124972445
* after: https://github.com/itsjfx/dsv/actions/runs/18125407686

I also changed the output of the releases page to have some links and look a bit nicer 💅

https://github.com/itsjfx/dsv/releases/tag/nightly